### PR TITLE
AddDotenvFile(..) doesn't throw

### DIFF
--- a/src/DotenvExtension.cs
+++ b/src/DotenvExtension.cs
@@ -115,27 +115,25 @@ namespace Frozzare.Dotenv
                 }
             }
 
-            if (!fileExists)
+            if (fileExists)
             {
-                throw new Exception("The configuration file .env was not found");
-            }
+				if (provider == null && Path.IsPathRooted(path))
+				{
+					// Real PhysicalFileProvider has a bug that don't allow dot files:
+					// https://github.com/aspnet/FileSystem/issues/232
+					provider = new FileProvider.PhysicalFileProvider(Path.GetDirectoryName(path));
+					path = Path.GetFileName(path);
+				}
 
-            if (provider == null && Path.IsPathRooted(path))
-            {
-                // Real PhysicalFileProvider has a bug that don't allow dot files:
-                // https://github.com/aspnet/FileSystem/issues/232
-                provider = new FileProvider.PhysicalFileProvider(Path.GetDirectoryName(path));
-                path = Path.GetFileName(path);
-            }
-
-            var source = new DotenvConfigurationSource
-            {
-                Path = path,
-                Optional = optional,
-                FileProvider = provider,
-                ReloadOnChange = reloadOnChange
-            };
-            builder.Add(source);
+				var source = new DotenvConfigurationSource
+				{
+					Path = path,
+					Optional = optional,
+					FileProvider = provider,
+					ReloadOnChange = reloadOnChange
+				};
+				builder.Add(source);
+			}
             return builder;
         }
     }


### PR DESCRIPTION
When setting up configuration in the Startup.cs, it seemed to go against the spirit of the injectable configuration to have the AddDotEnv() method throw an exception if it couldn't find the specified file.

The configuration files should be optional and the builder should be passed on to the next configuration build step in the chain.