### PR TITLE
AspNetCore configuration section support

### DIFF
--- a/src/Dotenv.cs
+++ b/src/Dotenv.cs
@@ -115,7 +115,7 @@ namespace Frozzare.Dotenv
         {
             var lines = content.Split('\n');
             var vars = new Dictionary<string, string>();
-            var regex = new Regex(@"^(?:export|)\s*([^\d+][\w_]+)\s?=\s?(.+)");
+            var regex = new Regex(@"^(?:export|)\s*([^\d+][:\w_]+)\s?=\s?(.+)");
             for (int i = 0; i < lines.Length; i++)
             {
                 var matches = regex.Match(lines[i]);

--- a/tests/DotenvConfigurationTest.cs
+++ b/tests/DotenvConfigurationTest.cs
@@ -1,3 +1,11 @@
+
+/*
+ * Written by Warwick Molloy GitHub|@WazzaMo
+ * to ensure AspNetCore log configuration can be
+ * specified as per AspNetCore documentation
+ * and code templates.
+ */
+
 using System;
 using System.IO;
 using System.Collections.Generic;
@@ -19,7 +27,8 @@ namespace Frozzare.Dotenv.Tests
 		protected IConfigurationRoot _Config;
 		private string _ConfigBody;
 
-		public DotenvConfigurationTest() {
+		public DotenvConfigurationTest()
+		{
 			_ConfigBody = @"
 				Foobar = ""hi there""
 				Logging_LogLevel_Simple = ""Special""
@@ -33,48 +42,55 @@ namespace Frozzare.Dotenv.Tests
 			SetupConfig(_TestFile);
 		}
 
-		public void Dispose() {
+		public void Dispose()
+		{
 			_TestFile.Dispose();
 		}
 
-		private void SetupConfig(TemporaryTestFile temp) {
+		private void SetupConfig(TemporaryTestFile temp)
+		{
 			_Builder = new ConfigurationBuilder();
 			_Builder.AddDotenvFile( temp.Path );
 			_Config = _Builder.Build();
 		}
 
 		[Fact]
-		public void simple_key_can_be_fetched() {
+		public void simple_key_can_be_fetched()
+		{
 			Assert.Equal("hi there", _Config["Foobar"]);
 		}
 
 		[Fact]
-		public void long_key_can_be_fetched() {
+		public void long_key_can_be_fetched()
+		{
 			Assert.Equal("Special", _Config["Logging_LogLevel_Simple"]);
 		}
 
 		[Fact]
-		public void key_in_section_can_be_retrieved() {
+		public void key_in_section_can_be_retrieved()
+		{
 			const string SECTION_KEY = "LogLevel_Default";
 			var section = _Config.GetSection("Logging");
 			Assert.NotNull( section[ SECTION_KEY ]);
 			Assert.True( section[SECTION_KEY].Length > 0 );
 		}
 
-		public class when_in_subsection_section : DotenvConfigurationTest {
+		public class when_in_subsection_section : DotenvConfigurationTest
+		{
 			IConfigurationSection _Logging;
 			IConfigurationSection _LogLevel;
 
-			public when_in_subsection_section() : base() {
+			public when_in_subsection_section() : base()
+			{
 				_Logging = _Config?.GetSection("Logging") ?? null;
 				_LogLevel = _Logging?.GetSection("LogLevel") ?? null;
 			}
 
 			[Fact]
-			public void subsection_of_subsection_can_be_dereferenced() {
+			public void subsection_of_subsection_can_be_dereferenced()
+			{
 				Assert.Equal("Trace", _LogLevel["Flux"]);
 			}
-
 		}
     }
 }

--- a/tests/DotenvConfigurationTest.cs
+++ b/tests/DotenvConfigurationTest.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Xunit;
+
+using Microsoft.Extensions.Configuration;
+
+using Frozzare.Dotenv;
+
+using TestHelper;
+
+
+namespace Frozzare.Dotenv.Tests
+{
+    public class DotenvConfigurationTest : IDisposable
+    {
+		private TemporaryTestFile _TestFile;
+		private ConfigurationBuilder _Builder;
+		private IConfigurationRoot _Config;
+		private string _ConfigBody;
+
+		public DotenvConfigurationTest() {
+			_ConfigBody = @"
+				Foobar = ""hi there""
+				Logging_LogLevel_Simple = ""Special""
+				Logging:IncludeScopes = false
+				Logging:LogLevel_Default = ""Warning""
+				Logging:LogLevel_Microsoft = ""Error""
+				Logging:LogLevel:Flux = ""Trace""
+				Logging:LogLevel:System = ""Blue""
+			";
+			_TestFile = new TemporaryTestFile(_ConfigBody);
+			SetupConfig(_TestFile);
+		}
+
+		public void Dispose() {
+			_TestFile.Dispose();
+		}
+
+		private void SetupConfig(TemporaryTestFile temp) {
+			_Builder = new ConfigurationBuilder();
+			_Builder.AddDotenvFile( temp.Path );
+			_Config = _Builder.Build();
+		}
+
+		[Fact]
+		public void simple_key_can_be_fetched() {
+			Assert.Equal("hi there", _Config["Foobar"]);
+		}
+
+		[Fact]
+		public void long_key_can_be_fetched() {
+			Assert.Equal("Special", _Config["Logging_LogLevel_Simple"]);
+		}
+    }
+}

--- a/tests/DotenvConfigurationTest.cs
+++ b/tests/DotenvConfigurationTest.cs
@@ -16,7 +16,7 @@ namespace Frozzare.Dotenv.Tests
     {
 		private TemporaryTestFile _TestFile;
 		private ConfigurationBuilder _Builder;
-		private IConfigurationRoot _Config;
+		protected IConfigurationRoot _Config;
 		private string _ConfigBody;
 
 		public DotenvConfigurationTest() {
@@ -51,6 +51,30 @@ namespace Frozzare.Dotenv.Tests
 		[Fact]
 		public void long_key_can_be_fetched() {
 			Assert.Equal("Special", _Config["Logging_LogLevel_Simple"]);
+		}
+
+		[Fact]
+		public void key_in_section_can_be_retrieved() {
+			const string SECTION_KEY = "LogLevel_Default";
+			var section = _Config.GetSection("Logging");
+			Assert.NotNull( section[ SECTION_KEY ]);
+			Assert.True( section[SECTION_KEY].Length > 0 );
+		}
+
+		public class when_in_subsection_section : DotenvConfigurationTest {
+			IConfigurationSection _Logging;
+			IConfigurationSection _LogLevel;
+
+			public when_in_subsection_section() : base() {
+				_Logging = _Config?.GetSection("Logging") ?? null;
+				_LogLevel = _Logging?.GetSection("LogLevel") ?? null;
+			}
+
+			[Fact]
+			public void subsection_of_subsection_can_be_dereferenced() {
+				Assert.Equal("Trace", _LogLevel["Flux"]);
+			}
+
 		}
     }
 }

--- a/tests/test-helpers/TemporaryTestFile.cs
+++ b/tests/test-helpers/TemporaryTestFile.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using Xunit;
+using Microsoft.Extensions.Configuration;
+
+namespace TestHelper {
+
+    public class TemporaryTestFile : IDisposable {
+		const string FILENAME = "./.env";
+
+		private string _FilenameUsed;
+
+		public TemporaryTestFile(string body) {
+			_FilenameUsed = MakeFileName();
+			EnsureNoFile();
+			CreateNewFile(body);
+		}
+
+		public void Dispose() {
+			EnsureNoFile();			
+		}
+
+		public string Path { get { return _FilenameUsed; }}
+
+		private string MakeFileName() {
+			DateTime now = DateTime.Now;
+			return FILENAME + $"-{now.Millisecond}";
+			// return FILENAME + $"-{now.Year}-{now.Month}-{now.Day}-{now.Hour}-{now.Minute}";
+		}
+
+		private void CreateNewFile(string body) {
+			using(StreamWriter writer = File.AppendText(_FilenameUsed)) {
+				writer.Write(body);
+				writer.Flush();
+			}
+		}
+        
+		private void EnsureNoFile() {
+			if (File.Exists(_FilenameUsed)) {
+				System.Console.WriteLine( $"Removing old {_FilenameUsed} file" );
+				File.Delete(_FilenameUsed);
+			}
+		}
+    }
+
+}

--- a/tests/test-helpers/TemporaryTestFile.cs
+++ b/tests/test-helpers/TemporaryTestFile.cs
@@ -25,7 +25,6 @@ namespace TestHelper {
 		private string MakeFileName() {
 			DateTime now = DateTime.Now;
 			return FILENAME + $"-{now.Millisecond}";
-			// return FILENAME + $"-{now.Year}-{now.Month}-{now.Day}-{now.Hour}-{now.Minute}";
 		}
 
 		private void CreateNewFile(string body) {


### PR DESCRIPTION
- Added TemporaryTestFile test helper to enable creation and auto-cleanup of temporary files during testing.
- Added test spec for AspNetCore IConfigurationSection support to determine when the code was passing.

Discovered the main problem stopping me from using section support in AspNetCore with dotnet-dotenv was the regex for processing environment variables was blocking the section separator - the (":") colon.